### PR TITLE
Revert "Bump werkzeug from 0.14.1 to 0.15.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Flask==1.0.2
 itsdangerous==0.24
 Jinja2==2.10
 MarkupSafe==1.0
-Werkzeug==0.15.3
+Werkzeug==0.14.1


### PR DESCRIPTION
Reverts NAU-Canopy-Project/CanopyDemo#6

Reverting so that I can fix the previous merge